### PR TITLE
Fixed ConnectionError bug and deleted issues bug in `github.py`

### DIFF
--- a/issueshark/backends/basebackend.py
+++ b/issueshark/backends/basebackend.py
@@ -1,15 +1,16 @@
-import abc
+import logging
 import os
 import sys
-import logging
+from abc import abstractmethod, ABCMeta
 
 
-class BaseBackend(metaclass=abc.ABCMeta):
+class BaseBackend(metaclass=ABCMeta):
     """
     BaseBackend from which all backends must inherit
     """
 
-    @abc.abstractproperty
+    @property
+    @abstractmethod
     def identifier(self):
         """
         Identifier of the backend
@@ -34,7 +35,7 @@ class BaseBackend(metaclass=abc.ABCMeta):
         if self.config is not None:
             self.debug_level = self.config.get_debug_level()
 
-    @abc.abstractmethod
+    @abstractmethod
     def process(self):
         """
         Method that is called if the collection process should be started

--- a/issueshark/backends/github.py
+++ b/issueshark/backends/github.py
@@ -1,19 +1,16 @@
+import datetime
+import logging
+import sys
 import time
 
-import sys
-import datetime
-import copy
-
+import dateutil.parser
+import requests
 from mongoengine import DoesNotExist
+from pycoshark.mongomodels import *
 from requests import RequestException
 from requests.auth import HTTPBasicAuth
 
 from issueshark.backends.basebackend import BaseBackend
-import logging
-import requests
-import dateutil.parser
-
-from pycoshark.mongomodels import *
 
 logger = logging.getLogger('backend')
 STATE_ALL = 'all'
@@ -32,6 +29,7 @@ class GithubBackend(BaseBackend):
     """
     Backend that collects issue from github
     """
+
     @property
     def identifier(self):
         """
@@ -69,7 +67,8 @@ class GithubBackend(BaseBackend):
         logger.info("Starting the collection process...")
 
         # Get last modification date (since then, we will collect bugs)
-        last_issue = Issue.objects(issue_system_id=self.issue_system_id).order_by('-updated_at').only('updated_at').first()
+        last_issue = Issue.objects(issue_system_id=self.issue_system_id).order_by('-updated_at').only(
+            'updated_at').first()
         starting_date = None
         if last_issue is not None:
             starting_date = last_issue.updated_at
@@ -105,7 +104,7 @@ class GithubBackend(BaseBackend):
 
         :param raw_issue: like we got it from github
         """
-        logger.debug('Processing issue %s' % raw_issue)
+        logger.debug('Processing issue %s' % raw_issue["url"])
         updated_at = dateutil.parser.parse(raw_issue['updated_at'])
         created_at = dateutil.parser.parse(raw_issue['created_at'])
 
@@ -148,38 +147,42 @@ class GithubBackend(BaseBackend):
         target_url = '%s/%s/events' % (self.config.tracking_url, system_id)
         events = self._send_request(target_url)
 
-        # Go through all events and create mongo objects from it
         events_to_store = []
-        for raw_event in events:
-            created_at = dateutil.parser.parse(raw_event['created_at'])
 
-            # If the event is already saved, we can just continue, because nothing will change on the event
-            try:
-                Event.objects(external_id=raw_event['id'], issue_id=mongo_issue.id).get()
-                continue
-            except DoesNotExist:
-                event = Event(external_id=raw_event['id'],
-                              issue_id=mongo_issue.id, created_at=created_at, status=raw_event['event'])
+        # Go through all events and create mongo objects from it
+        try:
+            for raw_event in events:
+                created_at = dateutil.parser.parse(raw_event['created_at'])
 
-            if raw_event['commit_id'] is not None:
-                # It can happen that a commit from another repository references this issue. Therefore, we can not
-                # find the commit, as it is not part of THIS repository
+                # If the event is already saved, we can just continue, because nothing will change on the event
                 try:
-                    vcs_system_ids = [system.id for system in
-                                      VCSSystem.objects(project_id=self.project_id).only('id').all()]
-
-                    event.commit_id = Commit.objects(vcs_system_id__in=vcs_system_ids,
-                                                 revision_hash=raw_event['commit_id']).only('id').get().id
+                    Event.objects(external_id=raw_event['id'], issue_id=mongo_issue.id).get()
+                    continue
                 except DoesNotExist:
-                    pass
+                    event = Event(external_id=raw_event['id'],
+                                  issue_id=mongo_issue.id, created_at=created_at, status=raw_event['event'])
 
-            if 'actor' in raw_event and raw_event['actor'] is not None:
-                event.author_id = self._get_people(raw_event['actor']['url'])
+                if raw_event['commit_id'] is not None:
+                    # It can happen that a commit from another repository references this issue. Therefore, we can not
+                    # find the commit, as it is not part of THIS repository
+                    try:
+                        vcs_system_ids = [system.id for system in
+                                          VCSSystem.objects(project_id=self.project_id).only('id').all()]
 
-            self._set_old_and_new_value_for_event(event, raw_event, mongo_issue)
-            mongo_issue.save()
+                        event.commit_id = Commit.objects(vcs_system_id__in=vcs_system_ids,
+                                                         revision_hash=raw_event['commit_id']).only('id').get().id
+                    except DoesNotExist:
+                        pass
 
-            events_to_store.append(event)
+                if 'actor' in raw_event and raw_event['actor'] is not None:
+                    event.author_id = self._get_people(raw_event['actor']['url'])
+
+                self._set_old_and_new_value_for_event(event, raw_event, mongo_issue)
+                mongo_issue.save()
+
+                events_to_store.append(event)
+        except TypeError:
+            logger.debug("Not storing events for %s." % target_url)
 
         # Bulk insert to database
         if events_to_store:
@@ -197,15 +200,14 @@ class GithubBackend(BaseBackend):
             if 'assignee' in raw_event and raw_event['assignee'] is not None:
                 event.new_value = self._get_people(raw_event['assignee']['url'])
 
-
-            #if 'assigner' in raw_event and raw_event['assigner'] is not None:
+            # if 'assigner' in raw_event and raw_event['assigner'] is not None:
             #    event.assigner_id = self._get_people(raw_event['assigner']['url'])
 
         if raw_event['event'] == 'unassigned':
             if 'assignee' in raw_event and raw_event['assignee'] is not None:
                 event.old_value = self._get_people(raw_event['assignee']['url'])
 
-            #if 'assigner' in raw_event and raw_event['assigner'] is not None:
+            # if 'assigner' in raw_event and raw_event['assigner'] is not None:
             #    event.assigner_id = self._get_people(raw_event['assigner']['url'])
 
         if raw_event['event'] == 'labeled' and 'label' in raw_event:
@@ -269,7 +271,7 @@ class GithubBackend(BaseBackend):
         """
         # Creates the target url for getting the issues
         target_url = self.config.tracking_url + "?state=" + search_state + "&page=" + str(pagecount) \
-            + "&per_page=100&sort=updated&direction=" + sorting
+                     + "&per_page=100&sort=updated&direction=" + sorting
 
         if start_date:
             target_url = target_url + "&since=" + str(start_date)
@@ -279,7 +281,7 @@ class GithubBackend(BaseBackend):
 
     def _get_people(self, user_url):
         """
-        Gets the person via the user url
+        Gets the person via the user url.
 
         :param user_url: url to the github API to get information of the user
         """
@@ -306,7 +308,10 @@ class GithubBackend(BaseBackend):
 
     def _send_request(self, url):
         """
-        Sends arequest using the requests library to the url specified
+        Sends a request using the requests library to the url specified.
+
+        NOTE: In case, the issue to be fetched has been deleted and if the events process requests fails,
+              its events would be skipped.
 
         :param url: url to which the request should be sent
         """
@@ -323,7 +328,15 @@ class GithubBackend(BaseBackend):
         tries = 1
         while tries <= 3:
             logger.debug("Sending request to url: %s (Try: %s)" % (url, tries))
-            resp = requests.get(url, headers=headers, proxies=self.config.get_proxy_dictionary(), auth=auth)
+            try:
+                resp = requests.get(url, headers=headers, proxies=self.config.get_proxy_dictionary(), auth=auth)
+            except requests.exceptions.ConnectionError:
+                time.sleep(2)
+                try:
+                    resp = requests.get(url, headers=headers, proxies=self.config.get_proxy_dictionary(), auth=auth)
+                except requests.exceptions.ConnectionError:
+                    logger.error("Connection Error while fetching data from url %s." % url)
+                    break
 
             if resp.status_code != 200:
                 logger.error("Problem with getting data via url %s. Error: %s" % (url, resp.text))
@@ -332,22 +345,28 @@ class GithubBackend(BaseBackend):
             else:
                 # It can happen that we exceed the github api limit. If we have only 1 request left we will wait
                 if 'X-RateLimit-Remaining' in resp.headers and int(resp.headers['X-RateLimit-Remaining']) <= 1:
-
                     # We get the reset time (UTC Epoch seconds)
                     time_when_reset = datetime.datetime.fromtimestamp(float(resp.headers['X-RateLimit-Reset']))
                     now = datetime.datetime.now()
 
-                    # Then we substract and add 10 seconds to it (so that we do not request directly at the threshold
-                    waiting_time = ((time_when_reset-now).total_seconds())+10
+                    # Then we subtract and add 10 seconds to it (so that we do not request directly at the threshold
+                    waiting_time = ((time_when_reset - now).total_seconds()) + 10
 
                     logger.info("Github API limit exceeded. Waiting for %0.5f seconds..." % waiting_time)
                     time.sleep(waiting_time)
 
                     resp = requests.get(url, headers=headers, proxies=self.config.get_proxy_dictionary(), auth=auth)
 
-                logger.debug('Got response: %s' % resp.json())
+                    try:
+                        logger.debug(
+                            'Got response: Issue-%s' % resp.json()[0]["url"] if isinstance(resp.json(), list) else
+                            resp.json()["url"])
+                    except IndexError:
+                        pass
 
                 return resp.json()
 
-        raise RequestException("Problem with getting data via url %s." % url)
-
+        if "events" in url:
+            return None
+        else:
+            raise RequestException("Problem with getting data via url %s." % url)

--- a/issueshark/backends/helpers/bugzillaagent.py
+++ b/issueshark/backends/helpers/bugzillaagent.py
@@ -1,9 +1,8 @@
+import time
 import urllib.parse
+from collections import OrderedDict
 
 import requests
-import time
-
-from collections import OrderedDict
 
 
 class BugzillaApiException(Exception):
@@ -17,6 +16,7 @@ class BugzillaAgent(object):
     """
     Class that is used to connect to the bugzilla API
     """
+
     def __init__(self, logger, config):
         """
         Initialization
@@ -32,8 +32,8 @@ class BugzillaAgent(object):
 
         # Get base url
         path = parsed_url.path.split('/')
-        path_without_endpoint = '/'.join(path[0:len(path)-1])
-        self.base_url = parsed_url.scheme+"://"+parsed_url.netloc+path_without_endpoint
+        path_without_endpoint = '/'.join(path[0:len(path) - 1])
+        self.base_url = parsed_url.scheme + "://" + parsed_url.netloc + path_without_endpoint
 
         self.username = config.issue_user
         self.password = config.issue_password
@@ -53,9 +53,9 @@ class BugzillaAgent(object):
         """
         options = {
             'product': self.project_name,
-            'offset': offset,
-            'limit': limit,
-            'order': 'creation_time%20ASC'
+            'offset' : offset,
+            'limit'  : limit,
+            'order'  : 'creation_time%20ASC'
         }
 
         if last_change_time is not None:
@@ -71,7 +71,7 @@ class BugzillaAgent(object):
         :param options: options for the request
         """
         try:
-            return self._send_request('user/'+str(id), options)['users'][0]
+            return self._send_request('user/' + str(id), options)['users'][0]
         except KeyError:
             return None
 
@@ -101,7 +101,8 @@ class BugzillaAgent(object):
         if new_since is not None:
             options['new_since'] = new_since
 
-        return self._send_request(('bug/%s/comment' % external_issue_id), new_since)['bugs'][str(external_issue_id)]['comments']
+        return self._send_request(('bug/%s/comment' % external_issue_id), new_since)['bugs'][str(external_issue_id)][
+            'comments']
 
     def _build_query(self, endpoint, options):
         if options is not None:

--- a/issueshark/backends/jirabackend.py
+++ b/issueshark/backends/jirabackend.py
@@ -1,19 +1,15 @@
 import copy
+import logging
+import sys
+import time
+from urllib.parse import urlparse, quote_plus
 
 import dateutil
-import sys
-
-import time
-from mongoengine import DoesNotExist
-
-from issueshark.backends.basebackend import BaseBackend
-from urllib.parse import urlparse, quote_plus
 from jira import JIRA, JIRAError
-
-import logging
-
+from mongoengine import DoesNotExist
 from pycoshark.mongomodels import *
 
+from issueshark.backends.basebackend import BaseBackend
 
 logger = logging.getLogger('backend')
 
@@ -29,6 +25,7 @@ class JiraBackend(BaseBackend):
     """
     Backend that collects data via the JIRA API
     """
+
     @property
     def identifier(self):
         """
@@ -54,25 +51,25 @@ class JiraBackend(BaseBackend):
         self.jira_client = None
 
         self.jira_mongo_terminology_mapping = {
-            'summary': 'title',
-            'description': 'desc',
-            'created': 'created_at',
-            'updated': 'updated_at',
-            'creator': 'creator_id',
-            'reporter': 'reporter_id',
-            'issuetype': 'issue_type',
-            'priority': 'priority',
-            'status': 'status',
-            'versions': 'affects_versions',
-            'components': 'components',
-            'labels': 'labels',
-            'resolution': 'resolution',
-            'fixVersions': 'fix_versions',
-            'assignee': 'assignee_id',
-            'issuelinks': 'issue_links',
-            'parent': 'parent_issue_id',
+            'summary'             : 'title',
+            'description'         : 'desc',
+            'created'             : 'created_at',
+            'updated'             : 'updated_at',
+            'creator'             : 'creator_id',
+            'reporter'            : 'reporter_id',
+            'issuetype'           : 'issue_type',
+            'priority'            : 'priority',
+            'status'              : 'status',
+            'versions'            : 'affects_versions',
+            'components'          : 'components',
+            'labels'              : 'labels',
+            'resolution'          : 'resolution',
+            'fixVersions'         : 'fix_versions',
+            'assignee'            : 'assignee_id',
+            'issuelinks'          : 'issue_links',
+            'parent'              : 'parent_issue_id',
             'timeoriginalestimate': 'original_time_estimate',
-            'environment': 'environment'
+            'environment'         : 'environment'
         }
 
     def process(self):
@@ -123,7 +120,7 @@ class JiraBackend(BaseBackend):
             issues = self.jira_client.search_issues(query, startAt=processed_results, maxResults=50, fields='summary')
             logger.debug('Found %d issues via url %s' %
                          (len(issues), self.jira_client._get_url('search?jql=%s&startAt=%d&maxResults=50' %
-                                                                (quote_plus(query), processed_results))))
+                                                                 (quote_plus(query), processed_results))))
             processed_results += 50
 
     def _create_url_to_jira_rest_interface(self):
@@ -134,7 +131,7 @@ class JiraBackend(BaseBackend):
         # We need to get the name of the project (how it is called in jira, e.g. 'ZOOKEEPER')
         parsed_url = urlparse(self.config.tracking_url)
 
-        rest_url = parsed_url.scheme+"://"+parsed_url.netloc
+        rest_url = parsed_url.scheme + "://" + parsed_url.netloc
 
         # If the path does not start with /rest, meaning there is something in between (e.g. "/jira"), we need
         # to add that to the server
@@ -183,7 +180,7 @@ class JiraBackend(BaseBackend):
                 logger.debug('Processing issue %s via url %s' % (
                     jira_issue_id,
                     self.jira_client._get_url('issue/%s?expand=changelog' % jira_issue_id))
-                )
+                             )
                 issue = self.jira_client.issue(jira_issue_id, expand='changelog')
                 logger.debug('Got fields: %s' % vars(issue.fields))
                 issue_not_retrieved = False
@@ -318,25 +315,25 @@ class JiraBackend(BaseBackend):
         :param at_name_jira: attribute name that should be returned
         """
         field_mapping = {
-            'summary': self._parse_string_field,
-            'description': self._parse_string_field,
-            'created': self._parse_date_field,
-            'updated': self._parse_date_field,
-            'creator': self._parse_author_details,
-            'reporter': self._parse_author_details,
-            'issuetype': self._parse_string_field,
-            'priority': self._parse_string_field,
-            'status': self._parse_string_field,
-            'versions': self._parse_array_field,
-            'components': self._parse_array_field,
-            'labels': self._parse_array_field,
-            'resolution': self._parse_string_field,
-            'fixVersions': self._parse_array_field,
-            'assignee': self._parse_author_details,
-            'issuelinks': self._parse_issue_links,
-            'parent': self._parse_parent_issue,
+            'summary'             : self._parse_string_field,
+            'description'         : self._parse_string_field,
+            'created'             : self._parse_date_field,
+            'updated'             : self._parse_date_field,
+            'creator'             : self._parse_author_details,
+            'reporter'            : self._parse_author_details,
+            'issuetype'           : self._parse_string_field,
+            'priority'            : self._parse_string_field,
+            'status'              : self._parse_string_field,
+            'versions'            : self._parse_array_field,
+            'components'          : self._parse_array_field,
+            'labels'              : self._parse_array_field,
+            'resolution'          : self._parse_string_field,
+            'fixVersions'         : self._parse_array_field,
+            'assignee'            : self._parse_author_details,
+            'issuelinks'          : self._parse_issue_links,
+            'parent'              : self._parse_parent_issue,
             'timeoriginalestimate': self._parse_string_field,
-            'environment': self._parse_string_field
+            'environment'         : self._parse_string_field
         }
 
         correct_function = field_mapping.get(at_name_jira)
@@ -550,12 +547,12 @@ class JiraBackend(BaseBackend):
         :param mongo_issue_id: issue to which this event is connected
         """
         terminology_mapping = {
-            'Component': 'components',
-            'Link': 'issuelinks',
+            'Component'  : 'components',
+            'Link'       : 'issuelinks',
             'Fix Version': 'fixVersions',
-            'Version': 'versions',
-            'Labels': 'labels',
-            'Parent': 'parent',
+            'Version'    : 'versions',
+            'Labels'     : 'labels',
+            'Parent'     : 'parent',
         }
 
         # If the try block succeeds, the event already exist in the database

--- a/issueshark/config.py
+++ b/issueshark/config.py
@@ -12,6 +12,7 @@ class Config(object):
     """
     Config object, that holds all configuration parameters
     """
+
     def __init__(self, args):
         """
         Initialization
@@ -56,10 +57,10 @@ class Config(object):
         4. Proxy host and port must be set if either of them is set
         """
         # allow public issue trackers without authentication
-        #if self.token is None and self.issue_user is None:
+        # if self.token is None and self.issue_user is None:
         #    raise ConfigValidationException('Token or issue user and issue password must be set.')
 
-        #if self.token is not None and self.issue_user is not None:
+        # if self.token is not None and self.issue_user is not None:
         #    raise ConfigValidationException('Either token or issue user/password combination is used!')
 
         if (self.issue_user is not None and self.issue_password is None) or \
@@ -79,10 +80,10 @@ class Config(object):
         Gets the correct debug level, based on :mod:`logging`
         """
         choices = {
-            'DEBUG': logging.DEBUG,
-            'INFO': logging.INFO,
-            'WARNING': logging.WARNING,
-            'ERROR': logging.ERROR,
+            'DEBUG'   : logging.DEBUG,
+            'INFO'    : logging.INFO,
+            'WARNING' : logging.WARNING,
+            'ERROR'   : logging.ERROR,
             'CRITICAL': logging.CRITICAL
         }
 
@@ -93,9 +94,9 @@ class Config(object):
         Gets the proxy string to do the requests
         """
         if self.proxy_password is None or self.proxy_username is None:
-            return 'http://'+self.proxy_host+':'+self.proxy_port
+            return 'http://' + self.proxy_host + ':' + self.proxy_port
         else:
-            return 'http://'+self.proxy_username+':'+self.proxy_password+'@'+self.proxy_host+':'+self.proxy_port
+            return 'http://' + self.proxy_username + ':' + self.proxy_password + '@' + self.proxy_host + ':' + self.proxy_port
 
     def get_proxy_dictionary(self):
         """
@@ -103,7 +104,7 @@ class Config(object):
         """
         if self._use_proxy():
             proxies = {
-                'http': self._get_proxy_string(),
+                'http' : self._get_proxy_string(),
                 'https': self._get_proxy_string()
             }
 
@@ -151,6 +152,3 @@ class Config(object):
                    self.issue_user,
                    self.issue_password
                )
-
-
-

--- a/issueshark/issueshark.py
+++ b/issueshark/issueshark.py
@@ -1,13 +1,13 @@
+import datetime
 import logging
+import sys
 import timeit
 
-import sys
-
-import datetime
 from mongoengine import connect, DoesNotExist
-from issueshark.backends.basebackend import BaseBackend
 from pycoshark.mongomodels import Project, IssueSystem
 from pycoshark.utils import create_mongodb_uri_string
+
+from issueshark.backends.basebackend import BaseBackend
 
 logger = logging.getLogger("main")
 
@@ -27,6 +27,7 @@ class IssueSHARK(object):
 
     5. Calls :func:`~issueshark.backends.basebackend.BaseBackend.process` on the found backend
     """
+
     def __init__(self):
         pass
 
@@ -68,4 +69,3 @@ class IssueSHARK(object):
 
         elapsed = timeit.default_timer() - start_time
         logger.info("Execution time: %0.5f s" % elapsed)
-


### PR DESCRIPTION
Replaced deprecated @abstractproperty decorator in [basebackend.py](https://github.com/smartshark/issueSHARK/blob/master/issueshark/backends/basebackend.py) with @abstractmethod as suggested [here](https://docs.python.org/3/library/abc.html#abc.abstractproperty). 

There was another critical error in `_send_request` function in `github.py`. If an issue is deleted, it seems the events URL doesn't work. 
For eg. check this [issue](https://api.github.com/repos/sympy/sympy/issues/2681) using the API URL. To confirm that the issue is deleted check [here](https://github.com/sympy/sympy/issues/2681). Its [comments](https://api.github.com/repos/sympy/sympy/issues/2681/comments) URL is working, but not the [events](https://api.github.com/repos/sympy/sympy/issues/2681/events).

In such cases, the `requests` library is not able to fetch data from the URL and the `_send_request` function raises a `RequestException`.  

To fix this, I checked whether the URL is an `events` URL and returned `None`. 

Another issue fixed in this PR, is that after a certain number of fetches done by the [request.get(...)](https://github.com/smartshark/issueSHARK/blob/master/issueshark/backends/github.py#L326), the GitHub server refuses the connection as too many requests are sent, throwing a ConnectionError (Max retries exceeded with URL). To tackle this problem, I added a sleep loop, `sleep(timeinsec)` and that did the trick. Another way to tackle this problem is that you may use the [Retry](https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.retry.Retry) function of `requests` and specifying the backoff factor.

Further, I changed the log outputs and reformatted the code for better readability.